### PR TITLE
fix: do not helm push on PR ci

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -60,4 +60,8 @@ jobs:
     - name: Package and Push Helm chart
       run: |
         helm package charts/missing-container-metrics
+
+    - name: Push Helm chart to OCI registry
+      if : github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+      run: |
         helm push missing-container-metrics-*.tgz oci://${{ env.REGISTRY }}/wonderland-platform/helm


### PR DESCRIPTION
We missed to remove the push for branches CI.
