### PR TITLE
use main branch for helm chart instead of tag

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -62,6 +62,6 @@ jobs:
         helm package charts/missing-container-metrics
 
     - name: Push Helm chart to OCI registry
-      if : github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+      if : github.event_name == 'push' && startsWith(github.ref, 'refs/branches/main')
       run: |
         helm push missing-container-metrics-*.tgz oci://${{ env.REGISTRY }}/wonderland-platform/helm


### PR DESCRIPTION
We are publishing the helm chart from the main branch after releasing a
new version.
