### PR TITLE
chore(build): add caching for container image build

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -61,6 +61,8 @@ jobs:
         push: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
 
     - name: Package and Push Helm chart
       run: |


### PR DESCRIPTION
To hopefully speed up multi architecture builds.
