### PR TITLE
Only stable Docker image updates from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,13 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    # Only stable releases: skip pre-release image tags (e.g. golang:1.27rc2)
+    ignore:
+      - dependency-name: "*"
+        versions:
+          - "*rc*"
+          - "*alpha*"
+          - "*beta*"
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:


### PR DESCRIPTION
Dependabot opened #89 to bump the `golang` base image to `1.27rc2-alpine3.24`, a release candidate. We only want stable releases for docker images.

This adds an `ignore` rule to the docker ecosystem for pre-release tags (`*rc*`, `*alpha*`, `*beta*`). Note the golang tags have no dash before `rc`, hence `*rc*` rather than `*-rc*`; it does not match the tags in use (`alpine3.24`, `1.26.5`).

`gomod` and `github-actions` are unchanged.

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)